### PR TITLE
Make Eclipse show visual progress of the refresh/build when using a refreshnow file

### DIFF
--- a/plugin/src/com/google/zoodiac/refreshnow/RefreshNowJob.java
+++ b/plugin/src/com/google/zoodiac/refreshnow/RefreshNowJob.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Tim De Baets
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     Luiz-Otavio "Z" Zorzella
+ *     Tim De Baets
+ *******************************************************************************/
+package com.google.zoodiac.refreshnow;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.resources.WorkspaceJob;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Status;
+
+public class RefreshNowJob extends WorkspaceJob {
+
+  static final String JOB_NAME_REFRESHING = "Refreshing files (Zoodiac)";
+  static final String JOB_NAME_BUILDING = "Building project (Zoodiac)";
+  
+  static final String REFRESH_NOW_COMPLETED_MESSAGE = "Refresh now completed";
+  static final String REFRESH_NOW_IN_PROGRESS_MESSAGE = "Refresh now in progress";
+  
+  private IProject project;
+  
+  public RefreshNowJob(IProject project) {
+    // Create job with an empty name for now, we will change the name in
+    // runInWorkspace().
+    super("");
+    this.project = project;
+  }
+  
+  public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
+    String balloonTitle = String
+      .format("Project '%s'", project.getName());
+    RefreshNowTask.displayMessage(
+        balloonTitle,
+        REFRESH_NOW_IN_PROGRESS_MESSAGE,
+        true);
+     
+    setName(JOB_NAME_REFRESHING);
+    logInfo(JOB_NAME_REFRESHING);
+    
+    project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
+
+    setName(JOB_NAME_BUILDING);
+    logInfo(JOB_NAME_BUILDING);
+   
+    // TODO: make optional?
+    project.build(
+        IncrementalProjectBuilder.INCREMENTAL_BUILD,
+        monitor);
+    
+    logInfo(REFRESH_NOW_COMPLETED_MESSAGE);
+       
+    RefreshNowTask.displayMessage(
+        balloonTitle,
+        REFRESH_NOW_COMPLETED_MESSAGE,
+        true);
+
+    return Status.OK_STATUS;
+  }
+  
+  // TODO: make common
+  void logInfo(String message) {
+    ILog log = Platform.getLog(getClass());
+    log.log(new Status(Status.INFO, "com.google.zoodiac", message));
+  }
+
+}

--- a/plugin/src/com/google/zoodiac/refreshnow/RefreshNowTask.java
+++ b/plugin/src/com/google/zoodiac/refreshnow/RefreshNowTask.java
@@ -12,11 +12,11 @@
 package com.google.zoodiac.refreshnow;
 
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
-import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.PlatformUI;
@@ -27,9 +27,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 class RefreshNowTask extends TimerTask {
 
-  private static final String REFRESH_NOW_COMPLETED_MESSAGE = "Refresh now completed";
-  private static final String REFRESH_NOW_IN_PROGRESS_MESSAGE = "Refresh now in progress";
-
   /**
    * Prevents some actions (such as shutdown) from happening at the very first 
    * time this is run. 
@@ -38,79 +35,65 @@ class RefreshNowTask extends TimerTask {
   
   @Override
   public synchronized void run() {
+    IWorkspaceRoot root;
+
     try {
-      IWorkspaceRoot root;
+      root = ResourcesPlugin.getWorkspace().getRoot();
+    } catch (IllegalStateException e) {
+      // The workspace has been closed (i.e. Eclipse is exiting). Ignoring it.
+      return;
+    }
 
-      try {
-        root = ResourcesPlugin.getWorkspace().getRoot();
-      } catch (IllegalStateException e) {
-        // The workspace has been closed (i.e. Eclipse is exiting). Ignoring it.
-        return;
-      }
+    final File shutdownNowWorkspace = 
+      new File (new File(root.getLocationURI()), "shutdownnow");
 
-      final File shutdownNowWorkspace = 
-        new File (new File(root.getLocationURI()), "shutdownnow");
-
-      final File refreshNowWorkspace = 
-        new File (new File(root.getLocationURI()), "refreshnow");
-      
-      boolean refreshAll = refreshNowWorkspace.delete();
-      
+    final File refreshNowWorkspace = 
+      new File (new File(root.getLocationURI()), "refreshnow");
+    
+    boolean refreshAll = refreshNowWorkspace.delete();
+    
+    if (shutdownNowWorkspace.exists()) {
       if (shutdownNowWorkspace.exists()) {
-        if (shutdownNowWorkspace.exists()) {
-          Thread deleteShutdownnowFile = new Thread(new Runnable() {
-            @Override
-            public void run() {
-              shutdownNowWorkspace.delete();
-            }
-          });
-          Runtime.getRuntime().addShutdownHook(deleteShutdownnowFile);
-          shutdownnow(shutdownNowWorkspace);
-        }
-      } else {
-        IProject[] projects = root.getProjects();
-        for (IProject project : projects) {
-          File uri = new File(project.getLocationURI());
-          File refreshNow = new File(uri, "refreshnow");
-          if (refreshAll || refreshNow.delete()) {
-            refreshnow(project);
-          } else {
-            final File shutdownNow = new File(uri, "shutdownnow");
-            if (shutdownNow.exists()) {
-              Thread deleteShutdownnowFile = new Thread(new Runnable() {
-                @Override
-                public void run() {
-                  // We delete the "shutdownnow" file as a JVM exit hook, so
-                  // its absence can be used as an indicator that the shutdown
-                  // is complete
-                  shutdownNow.delete();
-                }
-              });
-              Runtime.getRuntime().addShutdownHook(deleteShutdownnowFile);
-              shutdownnow(shutdownNow);
-            }
+        Thread deleteShutdownnowFile = new Thread(new Runnable() {
+          @Override
+          public void run() {
+            shutdownNowWorkspace.delete();
+          }
+        });
+        Runtime.getRuntime().addShutdownHook(deleteShutdownnowFile);
+        shutdownnow(shutdownNowWorkspace);
+      }
+    } else {
+      IProject[] projects = root.getProjects();
+      for (IProject project : projects) {
+        File uri = new File(project.getLocationURI());
+        File refreshNow = new File(uri, "refreshnow");
+        if (refreshAll || refreshNow.delete()) {
+          refreshnow(project);
+        } else {
+          final File shutdownNow = new File(uri, "shutdownnow");
+          if (shutdownNow.exists()) {
+            Thread deleteShutdownnowFile = new Thread(new Runnable() {
+              @Override
+              public void run() {
+                // We delete the "shutdownnow" file as a JVM exit hook, so
+                // its absence can be used as an indicator that the shutdown
+                // is complete
+                shutdownNow.delete();
+              }
+            });
+            Runtime.getRuntime().addShutdownHook(deleteShutdownnowFile);
+            shutdownnow(shutdownNow);
           }
         }
       }
-      firstTime = false;
-    } catch (final CoreException e) {
-      String balloonTitle = "RefreshNow plugin";
-      String message = e.getMessage();
-      displayMessage(balloonTitle, message, false);
     }
+    firstTime = false;
   }
 
-  private void refreshnow(IProject project) throws CoreException {
-    String balloonTitle = String
-      .format("Project '%s'", project.getName());
-    displayMessage(balloonTitle, REFRESH_NOW_IN_PROGRESS_MESSAGE, true);
-    project.refreshLocal(IResource.DEPTH_INFINITE, null);
-
-    project.build(
-        IncrementalProjectBuilder.INCREMENTAL_BUILD,
-        null);
-    
-    displayMessage(balloonTitle, REFRESH_NOW_COMPLETED_MESSAGE, true);
+  private void refreshnow(IProject project) {
+    RefreshNowJob job = new RefreshNowJob(project);
+    job.schedule();
   }
 
   private AtomicBoolean shuttingDown = new AtomicBoolean();
@@ -129,16 +112,21 @@ class RefreshNowTask extends TimerTask {
     
       @Override
       public void run() {
+        logInfo("Shutting down now");
         IWorkbench workbench = PlatformUI.getWorkbench();
         workbench.saveAllEditors(false);
         workbench.close();
       }
     };
-    Display.getDefault().asyncExec(
-      shutdownRunnable);
+    Display.getDefault().asyncExec(shutdownRunnable);
+  }
+  
+  void logInfo(String message) {
+    ILog log = Platform.getLog(getClass());
+    log.log(new Status(Status.INFO, "com.google.zoodiac", message));
   }
 
-  private void displayMessage(String balloonTitle, String message,
+  static void displayMessage(String balloonTitle, String message,
       boolean autoHide) {
     Display.getDefault().asyncExec(
       new RefreshNowMessage(balloonTitle, message, autoHide));


### PR DESCRIPTION
Right now when creating a `refreshnow` file, there are no visual clues at all in the Eclipse IDE that a refresh is in progress. The only way to see that a refresh is underway or has been completed is by checking the CPU/IO usage of the Eclipse process in task manager, which is far from ideal.

This pull request moves the code that triggers the refresh of the project files (and the building of the project) from the `RefreshNowTask` class to a new `RefreshNowJob` class, with the latter extending Eclipse's `WorkspaceJob`. This allows us to pass an Eclipse `IProgressMonitor` object to both the `refreshLocal()` and `build()` methods, which makes Eclipse show the visual progress of the refresh/build as a job in the **Progress** tab in Eclipse's user interface.