### PR TITLE
Properly handle simultaneously created refreshnow and shutdownnow files

### DIFF
--- a/plugin/src/com/google/zoodiac/refreshnow/RefreshNowJobListener.java
+++ b/plugin/src/com/google/zoodiac/refreshnow/RefreshNowJobListener.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Tim De Baets
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     Tim De Baets
+ *******************************************************************************/
+package com.google.zoodiac.refreshnow;
+
+import org.eclipse.core.runtime.jobs.IJobChangeEvent;
+import org.eclipse.core.runtime.jobs.JobChangeAdapter;
+
+public class RefreshNowJobListener extends JobChangeAdapter {
+  
+  private RefreshNowTask task;
+  
+  public RefreshNowJobListener(RefreshNowTask task) {
+    this.task = task;
+  }
+  
+  /* IJobChangeListener */
+  public void done(IJobChangeEvent event) {
+    // Passing null because the shutdownNow file was already deleted
+    task.shutdownnow(null);
+  }
+  
+}

--- a/plugin/src/com/google/zoodiac/refreshnow/RefreshNowTask.java
+++ b/plugin/src/com/google/zoodiac/refreshnow/RefreshNowTask.java
@@ -76,12 +76,17 @@ class RefreshNowTask extends TimerTask {
   private void refreshnow(IProject project, File shutdownNow) {
     RefreshNowJob job = new RefreshNowJob(project);
     
+    // If `shutdownNow` exists, it means there's both a "shutdownnow" and a
+    // "refreshnow" file. Let's delay shutting down until the refresh is
+    // completed.
     if (shutdownNow.exists()) {
       // We must delete the shutdownNow file now, otherwise run() would initiate
       // another shutdown before the refresh job has completed.
       // TODO: find a way to keep the file here and only delete on actual shutdown (to allow canceling a pending shutdown)
       shutdownNow.delete();
       
+      // Register a listener to the `RefreshNowJob` that initiates a shutdown
+      // when that job is done.
       RefreshNowJobListener listener = new RefreshNowJobListener(this);
       job.addJobChangeListener(listener);
     }


### PR DESCRIPTION
Currently, when creating a `refreshnow` and `shutdownnow` file at the same time, the plug-in first triggers a refresh, only to then immediately quit the Eclipse IDE.

This pull request improves this by waiting until Eclipse is done with refreshing/building and only then quitting the IDE.