### PR TITLE
With a refreshnow and shutdownnow file, wait for an idle indexer before quitting the IDE

### DIFF
--- a/plugin/META-INF/MANIFEST.MF
+++ b/plugin/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.filebuffers,
  org.eclipse.ui,
  org.eclipse.ui.editors,
- org.eclipse.ltk.core.refactoring
+ org.eclipse.ltk.core.refactoring,
+ org.eclipse.cdt.core
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Luiz-Otavio Zorzella
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/plugin/src/com/google/zoodiac/refreshnow/RefreshNowJob.java
+++ b/plugin/src/com/google/zoodiac/refreshnow/RefreshNowJob.java
@@ -17,10 +17,8 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.resources.WorkspaceJob;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 
 public class RefreshNowJob extends WorkspaceJob {
@@ -49,19 +47,19 @@ public class RefreshNowJob extends WorkspaceJob {
         true);
      
     setName(JOB_NAME_REFRESHING);
-    logInfo(JOB_NAME_REFRESHING);
+    RefreshNowTask.logInfo(JOB_NAME_REFRESHING);
     
     project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
 
     setName(JOB_NAME_BUILDING);
-    logInfo(JOB_NAME_BUILDING);
+    RefreshNowTask.logInfo(JOB_NAME_BUILDING);
    
     // TODO: make optional?
     project.build(
         IncrementalProjectBuilder.INCREMENTAL_BUILD,
         monitor);
     
-    logInfo(REFRESH_NOW_COMPLETED_MESSAGE);
+    RefreshNowTask.logInfo(REFRESH_NOW_COMPLETED_MESSAGE);
        
     RefreshNowTask.displayMessage(
         balloonTitle,
@@ -69,12 +67,6 @@ public class RefreshNowJob extends WorkspaceJob {
         true);
 
     return Status.OK_STATUS;
-  }
-  
-  // TODO: make common
-  void logInfo(String message) {
-    ILog log = Platform.getLog(getClass());
-    log.log(new Status(Status.INFO, "com.google.zoodiac", message));
   }
 
 }

--- a/plugin/src/com/google/zoodiac/refreshnow/RefreshNowJobListener.java
+++ b/plugin/src/com/google/zoodiac/refreshnow/RefreshNowJobListener.java
@@ -33,10 +33,6 @@ public class RefreshNowJobListener extends JobChangeAdapter
   
   public RefreshNowJobListener(RefreshNowTask task) {
     this.task = task;
-    // We must already register ourselves as index listener here - if we would
-    // wait until IJobChangeListener.done() we might have already missed the
-    // 'indexer idle' event, because that event could come earlier.
-    CCorePlugin.getIndexManager().addIndexerStateListener(this);
   }
   
   private void startTimer() {
@@ -67,6 +63,7 @@ public class RefreshNowJobListener extends JobChangeAdapter
   /* IJobChangeListener */
   public void done(IJobChangeEvent event) {
     jobDone = true;
+    CCorePlugin.getIndexManager().addIndexerStateListener(this);
     if (CCorePlugin.getIndexManager().isIndexerIdle()) {
       RefreshNowTask.logInfo("Job done and indexer is idle, starting timer");
       startTimer();

--- a/plugin/src/com/google/zoodiac/refreshnow/RefreshNowJobListener.java
+++ b/plugin/src/com/google/zoodiac/refreshnow/RefreshNowJobListener.java
@@ -11,21 +11,83 @@
  *******************************************************************************/
 package com.google.zoodiac.refreshnow;
 
+import java.util.Timer;
+import java.util.TimerTask;
+
+import org.eclipse.cdt.core.CCorePlugin;
+import org.eclipse.cdt.core.index.IIndexerStateEvent;
+import org.eclipse.cdt.core.index.IIndexerStateListener;
 import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 
-public class RefreshNowJobListener extends JobChangeAdapter {
+public class RefreshNowJobListener extends JobChangeAdapter
+    implements IIndexerStateListener {
+  
+  private static final long SECOND = 1000;
+  private static final long WAIT_SECONDS = 15;
+  private static final long WAIT_TIME = WAIT_SECONDS * SECOND;
   
   private RefreshNowTask task;
+  private Timer timer;
+  private boolean jobDone = false;
   
   public RefreshNowJobListener(RefreshNowTask task) {
     this.task = task;
+    // We must already register ourselves as index listener here - if we would
+    // wait until IJobChangeListener.done() we might have already missed the
+    // 'indexer idle' event, because that event could come earlier.
+    CCorePlugin.getIndexManager().addIndexerStateListener(this);
   }
   
-  /* IJobChangeListener */
-  public void done(IJobChangeEvent event) {
+  private void startTimer() {
+    stopTimer();
+    TimerTask timerTask = new TimerTask() {
+      @Override
+      public void run() {
+        stopTimer();
+        indexIdle();
+      }
+    };
+    timer = new Timer(true /* isDaemon */);
+    timer.schedule(timerTask, WAIT_TIME, WAIT_TIME);
+  }
+  
+  private void stopTimer() {
+    if (timer != null) {
+      timer.cancel();
+    }
+  }
+  
+  private void indexIdle() {
+    CCorePlugin.getIndexManager().removeIndexerStateListener(this);
     // Passing null because the shutdownNow file was already deleted
     task.shutdownnow(null);
   }
   
+  /* IJobChangeListener */
+  public void done(IJobChangeEvent event) {
+    jobDone = true;
+    if (CCorePlugin.getIndexManager().isIndexerIdle()) {
+      RefreshNowTask.logInfo("Job done and indexer is idle, starting timer");
+      startTimer();
+    }
+  }
+  
+  /* IIndexerStateListener */
+  @Override
+  public void indexChanged(IIndexerStateEvent event) {
+    RefreshNowTask.logInfo("Indexer state changed, idle: " +
+        event.indexerIsIdle() + ", job done: " +  jobDone);
+    
+    if (!jobDone) {
+      return;
+    }
+    
+    if (event.indexerIsIdle()) {
+      startTimer();
+    } else {
+      stopTimer();
+    }
+  }
+
 }

--- a/plugin/src/com/google/zoodiac/refreshnow/RefreshNowTask.java
+++ b/plugin/src/com/google/zoodiac/refreshnow/RefreshNowTask.java
@@ -77,8 +77,8 @@ class RefreshNowTask extends TimerTask {
     RefreshNowJob job = new RefreshNowJob(project);
     
     // If `shutdownNow` exists, it means there's both a "shutdownnow" and a
-    // "refreshnow" file. Let's delay shutting down until the refresh is
-    // completed.
+    // "refreshnow" file. Let's delay shutting down until the
+    // refresh/build/indexer is completed.
     if (shutdownNow.exists()) {
       // We must delete the shutdownNow file now, otherwise run() would initiate
       // another shutdown before the refresh job has completed.
@@ -86,7 +86,7 @@ class RefreshNowTask extends TimerTask {
       shutdownNow.delete();
       
       // Register a listener to the `RefreshNowJob` that initiates a shutdown
-      // when that job is done.
+      // when that job (and possible subsequent indexer update) is done.
       RefreshNowJobListener listener = new RefreshNowJobListener(this);
       job.addJobChangeListener(listener);
     }
@@ -138,8 +138,8 @@ class RefreshNowTask extends TimerTask {
     }
   }
   
-  void logInfo(String message) {
-    ILog log = Platform.getLog(getClass());
+  static void logInfo(String message) {
+    ILog log = Platform.getLog(RefreshNowTask.class);
     log.log(new Status(Status.INFO, "com.google.zoodiac", message));
   }
 


### PR DESCRIPTION
Pull request #5 already improved the behavior when creating a `refreshnow` and `shutdownnow` file at the same time, so that the plug-in waits until the refresh/build is done before quitting the IDE. However, after Eclipse has refreshed a project's files, it may also subsequently update the index with any files that were found to have changed. So the behavior could be improved even further to also take the index into account before quitting the IDE, which is the subject of this pull request.

With the change in this pull request, after noticing that Eclipse is done with refreshing/building, the plug-in will now also wait for Eclipse's indexer to become idle. As soon as the indexer has been idle for 15 seconds, it will quit the IDE (in case a `shutdownnow` file was created alongside the `refreshnow` file).

Note that I had to include the aforementioned change to `MANIFEST.MF` in my pull request, as it turns out that this is required for the `org.eclipse.cdt` imports in `RefreshNowJobListener`.